### PR TITLE
Owners with capital letters in name can't change flags

### DIFF
--- a/auto_include.ms
+++ b/auto_include.ms
@@ -491,7 +491,7 @@ proc(_cc_print_all_channels,
  */
 proc(_cc_flags, @channel, @flag, @bool,
 	@channelInfo = _cc_get_channel_info(@channel)
-	if (strip_colors(player()) != @channelInfo['owner']) {
+	if (to_lower(strip_colors(player())) != @channelInfo['owner']) {
 		die(color(RED).'This command is only available to the channel owner')
 	}
 	if (!(or(@flag == 'public', @flag == 'secret'))) {


### PR DESCRIPTION
Sorry about the LIGHT_GRAY, no clue how I missed that.

Anyways, one last bug came up tonight. Title should explain it all, just missed a to_lower() (As my username is all lowercase, didn't really catch it while testing. Whoops) 
